### PR TITLE
added security for public match put and delete

### DIFF
--- a/src/main/java/cat/udl/eps/softarch/mypadel/config/WebSecurityConfig.java
+++ b/src/main/java/cat/udl/eps/softarch/mypadel/config/WebSecurityConfig.java
@@ -30,6 +30,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 			    .antMatchers(HttpMethod.POST, "/players*/**").hasRole("ADMIN")
 			    .antMatchers(HttpMethod.DELETE, "/players*/**").hasRole("ADMIN")
 
+				.antMatchers(HttpMethod.PUT, "/publicMatches*/**").hasRole("ADMIN")
+				.antMatchers(HttpMethod.DELETE, "/publicMatches*/**").hasRole("ADMIN")
+
                 .antMatchers(HttpMethod.PUT, "/**/*").authenticated()
                 .antMatchers(HttpMethod.POST, "/**/*").authenticated()
                 .antMatchers(HttpMethod.DELETE, "/**/*").authenticated()


### PR DESCRIPTION
Anyone could delete or modify a match, now only admins can.